### PR TITLE
Added missing plugin-snapshot dependency to gradle-plugin

### DIFF
--- a/http-server/build.gradle
+++ b/http-server/build.gradle
@@ -6,6 +6,7 @@ buildscript {
 		maven { url "http://repo.spring.io/milestone" }
 		maven { url "http://repo.spring.io/libs-release-local" }
 		maven { url "http://repo.spring.io/libs-staging-local/" }
+		maven { url 'http://repo.spring.io/plugins-snapshot' }
 	}
 	dependencies {
 		classpath "org.springframework.boot:spring-boot-gradle-plugin:1.3.5.RELEASE"


### PR DESCRIPTION
Hi there!

While trying out your samples, I encountered issue with resolving `spring-cloud-contract-verifier-gradle-plugin:1.0.0.BUILD-SNAPSHOT` dependency. It turned out `http://repo.spring.io/plugins-snapshot` was missing in `buildscript` block.

This PR is to fix that.

Best Regards,
Bartosz
