### PR TITLE
Align package declaration with filesystem in MvcSpec

### DIFF
--- a/http-server/src/test/groovy/org/springframework/cloud/MvcSpec.groovy
+++ b/http-server/src/test/groovy/org/springframework/cloud/MvcSpec.groovy
@@ -1,4 +1,4 @@
-package com.toomuchcoding
+package org.springframework.cloud
 
 import org.springframework.cloud.contract.frauddetection.FraudDetectionController
 import com.jayway.restassured.module.mockmvc.RestAssuredMockMvc


### PR DESCRIPTION
Groovy forgives, but this is probably not intended. The package declaration says 'com.toomuchcoding' while being placed in 'org/springframework/cloud'.

I would also question if the sample applications should be placed in org.springframework.cloud at all, or rather in some 'demo' namespace....
